### PR TITLE
Normalize logs

### DIFF
--- a/koinos_encoder.go
+++ b/koinos_encoder.go
@@ -206,3 +206,6 @@ func KoinosColorLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder)
 func KoinosTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 	enc.AppendString(t.Format("2006-01-02 15:04:05.000000"))
 }
+
+// KoinosNoTimeEncoder does not encode timestamps in the log standard
+func KoinosNoTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {}

--- a/koinos_encoder.go
+++ b/koinos_encoder.go
@@ -184,6 +184,15 @@ func init() {
 	}
 }
 
+// KoinosLevelEncoder implements the Koinos log level encoding standard
+func KoinosLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+	if l == zapcore.WarnLevel {
+		enc.AppendString("warning")
+	} else {
+		enc.AppendString(l.String())
+	}
+}
+
 // KoinosColorLevelEncoder implements the Koinos log level color encoding standard
 func KoinosColorLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 	s, ok := _koinosColorString[l]

--- a/koinos_encoder.go
+++ b/koinos_encoder.go
@@ -105,9 +105,10 @@ func (ke *KoinosEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) 
 	arr := getSliceEncoder()
 	if ke.TimeKey != "" && ke.EncodeTime != nil {
 		ke.EncodeTime(ent.Time, arr)
+		arr.AppendString(" ")
 	}
 
-	arr.AppendString(" (")
+	arr.AppendString("(")
 	arr.AppendString(ke.AppID)
 	arr.AppendString(")")
 
@@ -206,6 +207,3 @@ func KoinosColorLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder)
 func KoinosTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 	enc.AppendString(t.Format("2006-01-02 15:04:05.000000"))
 }
-
-// KoinosNoTimeEncoder does not encode timestamps in the log standard
-func KoinosNoTimeEncoder(t time.Time, enc zapcore.PrimitiveArrayEncoder) {}

--- a/util.go
+++ b/util.go
@@ -27,17 +27,19 @@ func stringToLogLevel(level string) (zapcore.Level, error) {
 }
 
 // InitLogger initializes the logger with the given parameters
-func InitLogger(appName string, appID string, level string, dir string, color bool) error {
+func InitLogger(appName string, instanceID string, level string, dir string, color bool) error {
 	logLevel, err := stringToLogLevel(level)
 	if err != nil {
 		return err
 	}
 
-	initLogger(appName, appID, logLevel, dir, color)
+	initLogger(appName, instanceID, logLevel, dir, color)
 	return nil
 }
 
-func initLogger(appName string, appID string, level zapcore.Level, dir string, color bool) {
+func initLogger(appName string, instanceID string, level zapcore.Level, dir string, color bool) {
+	appID := fmt.Sprintf("%s.%s", appName, instanceID)
+
 	// Construct production encoder config, set time format
 	e := zap.NewDevelopmentEncoderConfig()
 	e.EncodeTime = KoinosTimeEncoder

--- a/util.go
+++ b/util.go
@@ -63,8 +63,8 @@ func initLogger(appName string, appID string, level zapcore.Level, dir string, c
 		// Construct lumberjack log roller
 		lj := &lumberjack.Logger{
 			Filename:   path.Join(dir, appName+".log"),
-			MaxSize:    1,   // 1 Mb
-			MaxBackups: 100, // 100 files
+			MaxSize:    1,  // 1 Mb
+			MaxBackups: 10, // 100 files
 		}
 
 		// Construct core

--- a/util.go
+++ b/util.go
@@ -44,6 +44,8 @@ func initLogger(appName string, instanceID string, level zapcore.Level, dir stri
 	e := zap.NewDevelopmentEncoderConfig()
 	if datetime {
 		e.EncodeTime = KoinosTimeEncoder
+	} else {
+		e.EncodeTime = KoinosNoTimeEncoder
 	}
 
 	if color {

--- a/util.go
+++ b/util.go
@@ -46,7 +46,7 @@ func initLogger(appName string, instanceID string, level zapcore.Level, dir stri
 	if color {
 		e.EncodeLevel = KoinosColorLevelEncoder
 	} else {
-		e.EncodeLevel = zapcore.LowercaseLevelEncoder
+		e.EncodeLevel = KoinosLevelEncoder
 	}
 
 	// Construct Console encoder for console output
@@ -59,7 +59,7 @@ func initLogger(appName string, instanceID string, level zapcore.Level, dir stri
 		var fileEncoder zapcore.Encoder
 		fe := zap.NewDevelopmentEncoderConfig()
 		fe.EncodeTime = KoinosTimeEncoder
-		fe.EncodeLevel = zapcore.LowercaseLevelEncoder
+		fe.EncodeLevel = KoinosLevelEncoder
 		fileEncoder = NewKoinosEncoder(fe, appID)
 
 		// Construct lumberjack log roller

--- a/util.go
+++ b/util.go
@@ -17,7 +17,7 @@ func stringToLogLevel(level string) (zapcore.Level, error) {
 		return zapcore.DebugLevel, nil
 	case "info":
 		return zapcore.InfoLevel, nil
-	case "warn":
+	case "warning":
 		return zapcore.WarnLevel, nil
 	case "error":
 		return zapcore.ErrorLevel, nil
@@ -65,8 +65,8 @@ func initLogger(appName string, instanceID string, level zapcore.Level, dir stri
 		// Construct lumberjack log roller
 		lj := &lumberjack.Logger{
 			Filename:   path.Join(dir, appName+".log"),
-			MaxSize:    1,  // 1 Mb
-			MaxBackups: 10, // 100 files
+			MaxSize:    1,   // 1 Mb
+			MaxBackups: 100, // 100 files
 		}
 
 		// Construct core

--- a/util.go
+++ b/util.go
@@ -27,22 +27,25 @@ func stringToLogLevel(level string) (zapcore.Level, error) {
 }
 
 // InitLogger initializes the logger with the given parameters
-func InitLogger(appName string, instanceID string, level string, dir string, color bool) error {
+func InitLogger(appName string, instanceID string, level string, dir string, color bool, datetime bool) error {
 	logLevel, err := stringToLogLevel(level)
 	if err != nil {
 		return err
 	}
 
-	initLogger(appName, instanceID, logLevel, dir, color)
+	initLogger(appName, instanceID, logLevel, dir, color, datetime)
 	return nil
 }
 
-func initLogger(appName string, instanceID string, level zapcore.Level, dir string, color bool) {
+func initLogger(appName string, instanceID string, level zapcore.Level, dir string, color bool, datetime bool) {
 	appID := fmt.Sprintf("%s.%s", appName, instanceID)
 
 	// Construct production encoder config, set time format
 	e := zap.NewDevelopmentEncoderConfig()
-	e.EncodeTime = KoinosTimeEncoder
+	if datetime {
+		e.EncodeTime = KoinosTimeEncoder
+	}
+
 	if color {
 		e.EncodeLevel = KoinosColorLevelEncoder
 	} else {

--- a/util.go
+++ b/util.go
@@ -45,7 +45,7 @@ func initLogger(appName string, instanceID string, level zapcore.Level, dir stri
 	if datetime {
 		e.EncodeTime = KoinosTimeEncoder
 	} else {
-		e.EncodeTime = KoinosNoTimeEncoder
+		e.EncodeTime = nil
 	}
 
 	if color {


### PR DESCRIPTION
Resolves koinos/koinos-internal#194.

## Brief description
Adds the ability to turn off logging to files. Does not gzip compress logs. Normalize `warning` log level.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
